### PR TITLE
Fix deploy configs to Elastic Beanstalk

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -4,27 +4,35 @@
     {
       "name": "app-root",
       "host": {
-        "sourcePath": "/var/app/staging/app"
+        "sourcePath": "/var/app/current/app/"
       }
     }
   ],
   "containerDefinitions": [
     {
+      "name": "db",
+      "image": "postgres",
+      "essential": true,
+      "memory": 128
+    },
+    {
       "name": "appsvr",
-      "image": "thehackerati/django-app-template",
+      "image": "thomaswhyyou/django-app-template-app",
       "essential": true,
       "memory": 128,
       "mountPoints": [
         {
           "sourceVolume": "app-root",
-          "containerPath": "/opt/app",
-          "readOnly": true
+          "containerPath": "/src/app/"
         }
+      ],
+      "links": [
+        "db"
       ]
     },
     {
       "name": "nginx",
-      "image": "thehackerati/django-app-template-nginx",
+      "image": "thomaswhyyou/django-app-template-nginx",
       "essential": true,
       "memory": 128,
       "portMappings": [
@@ -33,14 +41,14 @@
           "containerPort": 8000
         }
       ],
-      "links": [
-        "appsvr"
-      ],
       "mountPoints": [
         {
-          "sourceVolume": "awseb-logs-nginx",
-          "containerPath": "/var/log/nginx"
+          "sourceVolume": "app-root",
+          "containerPath": "/src/app/"
         }
+      ],
+      "links": [
+        "appsvr"
       ]
     }
   ]

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "appsvr",
-      "image": "thomaswhyyou/django-app-template-app",
+      "image": "thehackerati/django-app-template",
       "essential": true,
       "memory": 128,
       "mountPoints": [
@@ -32,7 +32,7 @@
     },
     {
       "name": "nginx",
-      "image": "thomaswhyyou/django-app-template-nginx",
+      "image": "thehackerati/django-app-template-nginx",
       "essential": true,
       "memory": 128,
       "portMappings": [

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,21 +1,12 @@
 FROM python:2.7
 ENV PYTHONUNBUFFERED 1
-RUN mkdir /opt/app
-WORKDIR /opt/app
 
-# XXX Do this at run time
-ADD requirements.txt /opt/app/
-RUN pip install -r requirements.txt
+# Install Python dependencies
+RUN mkdir -p /src/app/
+COPY requirements.txt /src/app/
+RUN pip install -r /src/app/requirements.txt
 
-# XXX Do this at deploy time
-# python manage.py migrate
-# python manage.py collectstatic
-
-# Create run/ directory inside /opt/app/ for uwsgi to communicate via socket.
-RUN test -d /opt/app/run/ || mkdir -p /opt/app/run/
-
-# Ensure we have django user which owns /opt/app/ directory.
+# Ensure we have django user with which uwsgi will run.
 RUN useradd -ms /bin/bash django
-RUN chown -R django:django /opt/app/
 
-CMD ["uwsgi", "--ini", "uwsgi.ini"]
+CMD uwsgi --ini /src/app/uwsgi.ini

--- a/app/uwsgi.ini
+++ b/app/uwsgi.ini
@@ -2,14 +2,13 @@
 [uwsgi]
 
 # Django directory (full path) inside the container
-chdir           = %d
+chdir           = /src/app/
 module          = app.wsgi:application
 
 master          = true
 processes       = 8
 
-socket          = /opt/app/run/uwsgi.sock
-chmod-socket    = 666
+socket          = :8001
 uid             = django
 gid             = django
 vacuum          = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ appsvr:
   build: ./app
   # dockerfile: "Dockerfile.dev"
   volumes:
-    - /opt/app
+    - ./app:/src/app/
   links:
     - db
 
@@ -15,8 +15,6 @@ nginx:
   ports:
     - "8000:8000"
   volumes:
-    - /www/public
-  volumes_from:
-    - appsvr
+    - ./app:/src/app/
   links:
     - appsvr

--- a/nginx/app_nginx.conf
+++ b/nginx/app_nginx.conf
@@ -2,7 +2,7 @@
 
 # the upstream component nginx needs to connect to
 upstream uwsgi_server {
-    server unix:/opt/app/run/uwsgi.sock;
+    server appsvr:8001;
 }
 
 # configuration of the server
@@ -18,11 +18,11 @@ server {
 
     # Django media
     location /media  {
-        alias /opt/app/media;
+        alias /src/app/media;
     }
 
     location /static {
-        alias /opt/app/static;
+        alias /src/app/static;
     }
 
     # Finally, send all non-media requests to the Django server.


### PR DESCRIPTION
- Rollback to http connection from unix socket for uwsgi+nginx; EB does
  not seem to support volume sharing between containers.
- Edit Dockerfiles to mount volume from host instance to access source
  code, instead of copying them into images themselves.
- Edit Dockerrun.aws.json & docker-compose.yml to reflect above changes.
